### PR TITLE
allow for decrease of stack size

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Custom Stack type for f90 FORTRAN that impliments a C style stack using pure f90
 * `fs_pop(stack, var)` : Pop top of stack into var.
 * `fs_peek(stack, var)` : Put top of stack into var without modifying stack.
 * `fs_reset_stack(stack)` : Reset stack to all 0's and reset stack pointer to 1.
-* `fs_realloc_stack(stack, int)` : Realloc stack to size int, without modifying contents. 
-* ***THIS DOES NOT SUPPORT MAKING A STACK SMALLER! IT WILL GO OOB IF YOU TRY, AND YOU MIGHT CRASH OR GET JUNK IN YOUR STACK.***
+* `fs_realloc_stack(stack, int)` : Realloc stack to size int, without modifying contents. Can either increase or decrease stack size.
 * `fs_cleanup_stack(stack)` : Dealloc stack. Use at  end of programs.
 
 ## Internals:

--- a/fstack.f90
+++ b/fstack.f90
@@ -53,12 +53,14 @@ module fstack
             type(fs_stack), intent(inout) :: stack
             integer, intent(in) :: x
             type(fs_stack) :: tmpstack
+            integer :: upper
             tmpstack = fs_create_stack(stack%stack_size)
             tmpstack%stack(1:stack%stack_size) = stack%stack(1:stack%stack_size)
             tmpstack%stack_size = stack%stack_size
             deallocate(stack%stack)
             allocate(stack%stack(x))
-            stack%stack(1:tmpstack%stack_size) = tmpstack%stack(1:tmpstack%stack_size)
+            upper = min(x, tmpstack%stack_size) ! allow for increase or decrease of stack_size
+            stack%stack(1:upper) = tmpstack%stack(1:upper)
             stack%stack_size = x
             deallocate(tmpstack%stack)
         end subroutine fs_realloc_stack


### PR DESCRIPTION
Allow for decrease of stack size in `realloc` by checking to avoid out-of-bounds.
Obviously if the stack size is decreased, data will be lost.